### PR TITLE
Read configuration properties directly from ENV variables

### DIFF
--- a/src/FlexiPeeHP/FlexiBeeRO.php
+++ b/src/FlexiPeeHP/FlexiBeeRO.php
@@ -497,6 +497,8 @@ class FlexiBeeRO extends \Ease\Sand {
             $this->$name = $options[$name];
         } elseif (array_key_exists($constant, $options)) {
             $this->$name = $options[$constant];
+        } elseif (property_exists($this, $name) && ($env = getenv($constant)) && !empty($env)) {
+            $this->$name = getenv($constant);
         } else {
             if (property_exists($this, $name) && !empty($constant) && defined($constant)) {
                 $this->$name = constant($constant);


### PR DESCRIPTION
When using Laravel/Symfony framework with .env file, we can read ENV variables directly without setting constants.